### PR TITLE
Fix: revert shebang

### DIFF
--- a/FailureLink.py
+++ b/FailureLink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # FailureLink post-processing script for NZBGet
 #


### PR DESCRIPTION
- revert the original shebang, as the latest version of nzbget works well with this shebang on POSIX systems