### PR TITLE
Fix: deprication warnings, TypeError

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,5 +10,5 @@ jobs:
   tests:
     uses: nzbgetcom/nzbget-extensions/.github/workflows/python-tests.yml@main
     with:
-      python-versions: "3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12"
+      python-versions: "3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12"
       supported-python-versions: "3.9 3.10 3.11 3.12"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 
 ## NZBGet Versions
 
-- pre-release v23+  [v3.0](https://github.com/nzbgetcom/Extension-FailureLink/releases/tag/v3.0)
-- stable  v22 [v2.0](https://github.com/nzbgetcom/Extension-FailureLink/releases/tag/v2.0)
-- legacy  v21 [v2.0](https://github.com/nzbgetcom/Extension-FailureLink/releases/tag/v2.0)
+- pre-release v23+ [v3.1](https://github.com/nzbgetcom/Extension-FailureLink/releases/tag/v3.1)
+- stable v22 [v2.0](https://github.com/nzbgetcom/Extension-FailureLink/releases/tag/v2.0)
 
 > **Note:** This script is compatible with python 3.8.x and above.
 If you need support for Python 2.x or older Python3.x versions please use [v1.21](https://github.com/nzbgetcom/Extension-FailureLink/releases/tag/v1.21) release.

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/nzbgetcom/Extension-FailureLink/",
 	"kind": "POST-PROCESSING",
 	"displayName": "Failure Link",
-	"version": "3.0.0",
+	"version": "3.1",
 	"author": "Andrey Prygunkov",
 	"license": "GNU",
 	"about": "Checks videos to determine if they are corrupt. Inform indexer site about failed or corrupt download and request a replacement nzb.",

--- a/test_data/test_response.xml
+++ b/test_data/test_response.xml
@@ -1,6 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
 <array>
 <data>
+<value>
+<struct>
+<member><name>NZBID</name><value><i4>2</i4></value></member>
+<member><name>NZBFilename</name><value><string>2.nzb</string></value></member>
+</struct>
+</value>
 <value>
 <struct>
 <member><name>NZBID</name><value><i4>1</i4></value></member>


### PR DESCRIPTION
[Issue](https://github.com/nzbgetcom/nzbget/issues/75)

## Description

- replaced 'cgi' with 'EmailMessage' due to deprication in Python3.13;
- fixed a TypeError: "a bytes-like object is required, not 'str'";
- fixed xml parsing;
- use 'unittest' instead of custom framework;
- removed Python 3.2 from tests.yaml;

## Testing

By @dnzbk:
 - NZBGet v23.1/Windows 11;